### PR TITLE
add missing next.config.js step to Next.js readme

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -18,6 +18,12 @@ module.exports = {
 }
 ```
 
+Next, create a `next.config.js` file and add the following configuration so Next can handle css file imports: 
+```
+const withCSS = require('@zeit/next-css')
+module.exports = withCSS()
+```
+
 Next, create a CSS file in your `static` folder for your Tailwind styles. We've used `static/css/tailwind.css` for this example:
 
 ```css


### PR DESCRIPTION
`@zeit/next-css` needs to be configured with a `next.config.js` file.

The project includes the file already but it wasn't mentioned in the readme so I just added the step.