### PR TITLE
Svelte update setup instructions in readme

### DIFF
--- a/examples/svelte/README.md
+++ b/examples/svelte/README.md
@@ -55,9 +55,8 @@ Update your `package.json` with the custom scripts.
 "scripts": {
     "watch:tailwind": "postcss public/tailwind.css -o public/index.css -w",
     "build:tailwind": "NODE_ENV=production postcss public/tailwind.css -o public/index.css",
-    "dev": "run-p start:dev autobuild watch:build",
-    "build": "npm run build:tailwind && rollup -c",
-
+    "dev": "run-p start:dev autobuild watch:tailwind",
+    "build": "npm run build:tailwind && rollup -c"
 }
 ```
 


### PR DESCRIPTION
The setup instruction in the readme file wasn't in sync with the package.json and not valid anymore.

Before:

```
> run-p start:dev autobuild watch:build

ERROR: Task not found: "watch:build"
```


After:

``
Your application is ready~!
``