### PR TITLE
Align borat to the center in Sapper example

### DIFF
--- a/examples/sapper/src/routes/index.svelte
+++ b/examples/sapper/src/routes/index.svelte
@@ -18,7 +18,7 @@
 	img {
 		width: 100%;
 		max-width: 400px;
-		margin: 0 0 1em 0;
+		margin:0 auto;
 	}
 
 	p {


### PR DESCRIPTION
Currently aligned to the left despite the text-center due to the max-width constraint.