### PR TITLE
Jekyll: Upgrade to Tailwind CSS 1.2.0, fix purgecss, minor fixes

### DIFF
--- a/examples/jekyll/Gemfile
+++ b/examples/jekyll/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.8"
+gem "jekyll", "~> 3.8.6"
 
 group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.13.0'
@@ -10,7 +10,11 @@ group :jekyll_plugins do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+# and associated library.
+install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+  gem "tzinfo", "~> 1.2"
+  gem "tzinfo-data"
+end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.0" if Gem.win_platform?
+gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?

--- a/examples/jekyll/Gemfile
+++ b/examples/jekyll/Gemfile
@@ -6,6 +6,7 @@ group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.13.0'
   gem 'jekyll-postcss', '~> 0.2.2'
   gem 'jekyll-purgecss', '~> 0.3.0'
+  gem 'jekyll-seo-tag', '~> 2.6', '>= 2.6.1'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/examples/jekyll/Gemfile
+++ b/examples/jekyll/Gemfile
@@ -1,10 +1,11 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.8.5"
+gem "jekyll", "~> 3.8"
 
 group :jekyll_plugins do
-  gem "jekyll-postcss"
-  gem "jekyll-purgecss"
+  gem 'jekyll-feed', '~> 0.13.0'
+  gem 'jekyll-postcss', '~> 0.2.2'
+  gem 'jekyll-purgecss', '~> 0.3.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -12,4 +13,3 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
-

--- a/examples/jekyll/_config.yml
+++ b/examples/jekyll/_config.yml
@@ -11,8 +11,10 @@
 # Build settings
 markdown: kramdown
 plugins:
+  - jekyll-feed
   - jekyll-postcss
   - jekyll-purgecss
+  - jekyll-seo-tag
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/examples/jekyll/_config.yml
+++ b/examples/jekyll/_config.yml
@@ -20,14 +20,15 @@ plugins:
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
 exclude:
+  - .gitignore
+  - bin
   - Gemfile
   - Gemfile.lock
+  - netlify.toml
   - node_modules
-  - yarn.lock
+  - package.json
   - package-lock.json
-  - README.md
   - postcss.config.js
   - purgecss.config.js
-  - netlify.toml
-  - bin
-  - .gitignore
+  - README.md
+  - yarn.lock

--- a/examples/jekyll/_config.yml
+++ b/examples/jekyll/_config.yml
@@ -21,10 +21,8 @@ plugins:
 # to override the default setting.
 exclude:
   - .gitignore
-  - bin
   - Gemfile
   - Gemfile.lock
-  - netlify.toml
   - node_modules
   - package.json
   - package-lock.json

--- a/examples/jekyll/package.json
+++ b/examples/jekyll/package.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
-    "autoprefixer": "^9.3.1",
-    "postcss-cli": "^6.0.1",
+    "autoprefixer": "^9.7.6",
+    "postcss-cli": "^7.1.0",
     "postcss-import": "^12.0.1",
-    "purgecss": "^1.1.0",
-    "tailwindcss": "^1.0.0"
+    "purgecss": "^2.1.2",
+    "tailwindcss": "^1.2.0"
   }
 }

--- a/examples/jekyll/purgecss.config.js
+++ b/examples/jekyll/purgecss.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   content: ["./_site/**/*.html"],
   css: ["./_site/css/site.css"],
-  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
+  // Extractor regex taken from the Tailwind docs
+  // https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css-with-purgecss
+  defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
 };


### PR DESCRIPTION
Hey!

Thanks for all your work on Tailwind CSS and these setup examples. They're awesome :)

I was working with Jekyll for the past few days and came across a few problems. I fixed all of them and would like to contribute them back to this repository.

This also fixes #56 in which purgecss was not working. I noticed this due to the "generated" `site.css` being 1.1MB in size, which is the original size. After fixing purgecss, its size is now 8kb - sounds more reasonable.

## Major Changes

* **Upgrade to Tailwind CSS 1.2.0**.
*  **Fix purgecss**: Upgrade purgecss to v2, upgrade other JS dependencies, update extractor regex from [Tailwind docs](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css-with-purgecss).
* **Fix jekyll not generating site**: The dependencies `jekyll-feed` and `jekyll-seo-tag` were missing, both in the `Gemfile` and in the `_config.yml`. Their (liquid) tags were however used in `layouts/default.html`. So I assume the original intent was to include them and fixed it.

## Minor Changes

* Clean up `Gemfile`: Sync it with what jekyll generates for a new project (jekyll version `3.8.6`).
* Clean up `exclude` list in `_config.yml`: Order alphabetically, remove unused entries (`bin` and `netlify.toml`), add `package.json` which was included in builds so far.