### PR TITLE
Fix Typo of WordPress word

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please note that these examples are for the most part contributed and maintained
 - [Sapper](examples/sapper)
 - [Laravel](examples/laravel-postcss-only) (PostCSS-only)
 - [Gridsome](examples/gridsome)
-- [Wordpress](examples/wordpress-laravel-mix) (using Laravel Mix)
+- [WordPress](examples/wordpress-laravel-mix) (using Laravel Mix)
 - [Statamic v2](examples/statamic-v2-laravel-mix) (using Laravel Mix)
 - [Jekyll](examples/jekyll)
 


### PR DESCRIPTION
In the WordPress Community, we always try to write captital_P in WordPress.

For Reference:
- [https://clarkwp.wordpress.com/2014/04/30/why-is-the-p-in-wordpress-important/](https://clarkwp.wordpress.com/2014/04/30/why-is-the-p-in-wordpress-important/l)
- [https://developer.wordpress.org/reference/functions/capital_p_dangit/](https://developer.wordpress.org/reference/functions/capital_p_dangit/)